### PR TITLE
added Electron desktopCapturer

### DIFF
--- a/src/electron/electron_api.js
+++ b/src/electron/electron_api.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { app, ipcMain, net, shell } from "electron";
+import { app, ipcMain, net, shell, desktopCapturer } from "electron";
 import fs from "fs";
 import path from "path";
 import mkdirp from "mkdirp";
@@ -125,6 +125,44 @@ class ElectronApi
             }
             event.returnValue = deps.filter((dep) => { return dep.type === "npm"; }).map((dep) => { return dep.src[0]; });
         });
+
+        ipcMain.handle("getDesktopCaptureSources", async (event, opts) =>
+        {
+            try
+            {
+                const sources = await this._getRawDesktopSources(opts);
+                console.log("[Main] getDesktopCaptureSources IPC returning", sources.length, "sources");
+                return sources;
+            }
+            catch (e)
+            {
+                console.error("[Main] Error in getDesktopCaptureSources IPC:", e);
+                throw e;
+            }
+        });
+    }
+
+    async _getRawDesktopSources(data)
+    {
+        const opts = data || {
+            "types": ["window", "screen"],
+            "thumbnailSize": { "width": 0, "height": 0 }
+        };
+        const sources = await desktopCapturer.getSources(opts);
+        return sources.map((source) =>
+        {
+            return {
+                "id": source.id,
+                "name": source.name,
+            };
+        });
+    }
+
+    async getDesktopCaptureSources(data)
+    {
+        const result = await this._getRawDesktopSources(data);
+        console.log("DESKTOP SOURCES FOUND:", result.length);
+        return this.success("OK", result, true);
     }
 
     async talkerMessage(cmd, data, topicConfig = {})

--- a/src_client/electron_editor.js
+++ b/src_client/electron_editor.js
@@ -276,6 +276,7 @@ export default class ElectronEditor
         this._talkerTopics[TalkerAPI.CMD_UPLOAD_OP_DEPENDENCY] = {};
         this._talkerTopics[TalkerAPI.CMD_GET_PATCH_SUMMARY] = {};
         this._talkerTopics[TalkerAPI.CMD_SEND_ERROR_REPORT] = {};
+        this._talkerTopics["getDesktopCaptureSources"] = {};
 
         this._talkerTopics[TalkerAPI.CMD_ELECTRON_RENAME_OP] = { };
         this._talkerTopics[TalkerAPI.CMD_ELECTRON_DELETE_OP] = {};


### PR DESCRIPTION
PR to add an Op, "DesktopTexture",  that implements the [Screen Capture API](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Capture_API). The Screen Capture API allows individual windows or the entire screen to be captured as a media stream. This works similar to the [WebcamTexture Op](https://cables.gl/op/Ops.Gl.Textures.WebcamTexture_v3).

The Electron module [desktopCapturer](https://www.electronjs.org/docs/latest/api/desktop-capturer) is used to get the available windows. 
The User can select a window in the Op, just like selecting a webcam in the WebcamTexture. 

User interaction is not required to initiate the screen capture when run in cables standalone 

Created with Google Gemini. Tested on cables standalone for MacOS