### PR TITLE
Transparent popout canvas

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -995,6 +995,45 @@ class ElectronApp
             return { "action": "allow" };
         });
 
+        this.editorWindow.webContents.setWindowOpenHandler(({ url, frameName }) =>
+        {
+            if (url && url.startsWith("http"))
+            {
+                shell.openExternal(url);
+                return { "action": "deny" };
+            }
+
+            const options = {
+                "action": "allow",
+                "overrideBrowserWindowOptions": {
+                    "autoHideMenuBar": true,
+                    "backgroundColor": "#222",
+                    "webPreferences": {
+                        "partition": settings.SESSION_PARTITION,
+                        "nodeIntegration": true,
+                        "nodeIntegrationInSubFrames": true,
+                        "contextIsolation": false,
+                        "backgroundThrottling": false,
+                        "autoplayPolicy": "no-user-gesture-required"
+                    }
+                }
+            };
+
+            if (frameName.startsWith("view#"))
+            {
+                const transparent = settings.getUserSetting("transparentpopout", false);
+                if (transparent)
+                {
+                    options.overrideBrowserWindowOptions.transparent = true;
+                    options.overrideBrowserWindowOptions.frame = false;
+                    options.overrideBrowserWindowOptions.hasShadow = false;
+                    options.overrideBrowserWindowOptions.backgroundColor = "#00000000";
+                }
+            }
+
+            return options;
+        });
+
         this.editorWindow.webContents.on("devtools-opened", (event, win) =>
         {
             settings.set(settings.OPEN_DEV_TOOLS_FIELD, true);

--- a/src_client/cables_electron.js
+++ b/src_client/cables_electron.js
@@ -117,6 +117,16 @@ export default class CablesElectron
                             this.gui.on("uiloaded", () =>
                             {
                                 if (this.editor && this.editor.config && !this.editor.config.patchFile) this.gui.setStateUnsaved();
+                                if (this.gui.userSettings && this.gui.userSettings.add)
+                                {
+                                    this.gui.userSettings.add({
+                                        "name": "transparentpopout",
+                                        "label": "Transparent Popout Canvas",
+                                        "category": "Standalone",
+                                        "type": "boolean",
+                                        "defaultValue": false
+                                    });
+                                }
                             });
 
                             const corePatch = this.gui.corePatch();

--- a/src_client/cmd_electron.js
+++ b/src_client/cmd_electron.js
@@ -24,6 +24,13 @@ function bytesArrToBase64(arr)
     return result;
 }
 
+// CABLES_CMD_ELECTRON.toggleTransparentPopout = () =>
+// {
+//     const current = gui.userSettings.get("transparentpopout", true);
+//     gui.userSettings.set("transparentpopout", !current);
+//     cablesElectron.editor.notify("Transparent popout canvas: " + (!current ? "enabled" : "disabled"));
+// };
+
 CABLES_CMD_ELECTRON.openOpDir = (opId = null, opName = null) =>
 {
     const gui = cablesElectron.gui;
@@ -240,6 +247,26 @@ CABLES_CMD_ELECTRON_OVERRIDES.RENDERER = {};
 CABLES_CMD_ELECTRON_OVERRIDES.RENDERER.fullscreen = () =>
 {
     cablesElectron.editor.api("cycleFullscreen", { }, (_err, r) => {});
+};
+
+CABLES_CMD_ELECTRON_OVERRIDES.RENDERER.popoutCanvas = () =>
+{
+    const gui = cablesElectron.gui;
+    if (gui && gui.canvasManager)
+    {
+        gui.canvasManager.popOut();
+        if (gui.canvasManager.subWindow)
+        {
+            const transparent = gui.userSettings.get("transparentpopout", false);
+            if (transparent)
+            {
+                const nDocument = gui.canvasManager.subWindow.document;
+                const style = nDocument.createElement("style");
+                style.innerHTML = "body { background-color: transparent !important; } .bgpatternDark, .bgPatternDark { background-image: none !important; background-color: transparent !important; }";
+                nDocument.body.appendChild(style);
+            }
+        }
+    }
 };
 
 CABLES_CMD_ELECTRON_OVERRIDES.UI = {};


### PR DESCRIPTION
This Pull Request adds an Editor Preference option for Cables standalone to open the Popout Canvas in a transparent window.  

related to issue [7428](https://github.com/cables-gl/cables/issues/7428)

Created with Gemini AI, tested in MacOS 26.3