### PR TITLE
Adding a new endpoint protocol esm:// to load esm js files

### DIFF
--- a/src/electron/electron_endpoint.js
+++ b/src/electron/electron_endpoint.js
@@ -16,6 +16,17 @@ import projectsUtil from "../utils/projects_util.js";
 
 protocol.registerSchemesAsPrivileged([
     {
+        "scheme": "esm",
+        "privileges": {
+            "secure": true,
+            "stream": true,
+            "bypassCSP": true,
+            "supportFetchAPI": true,
+            "corsEnabled": true,
+            "allowServiceWorkers": true
+        }
+    },
+    {
         "scheme": "cables",
         "privileges": {
             "bypassCSP": true,
@@ -129,6 +140,35 @@ class ElectronEndpoint
                 {
                     return net.fetch(request.url, { "bypassCustomProtocolHandlers": true });
                 }
+            }
+        });
+
+
+        ses.protocol.handle("esm", async (request) =>
+        {
+            const urlPath = request.url.replace("esm://", "").split("?")[0];
+
+            let file = "";
+            if (path.isAbsolute(urlPath))
+            {
+                file = urlPath;
+            }
+            else
+            {
+                // 1. Try project root (patch directory)
+                file = helper.fileURLToPath(urlPath, true);
+            }
+
+            try
+            {
+                const response = await net.fetch(helper.pathToFileURL(file), { "bypassCustomProtocolHandlers": true });
+                this._addDefaultHeaders(request, response, file);
+                response.headers.set("Access-Control-Allow-Origin", "*");
+                return response;
+            }
+            catch (e)
+            {
+                return new Response(null, { "status": 404 });
             }
         });
 
@@ -545,6 +585,8 @@ class ElectronEndpoint
                 response.headers.append("Content-Length", (endByte + 1) - startByte);
             }
             let mimeType = mime.getType(existingFile);
+            if (existingFile.endsWith(".mjs") || existingFile.endsWith(".js")) mimeType = "text/javascript";
+            if (existingFile.endsWith(".wasm")) mimeType = "application/wasm";
             if (mimeType)
             {
                 if (mimeType === "application/node") mimeType = "text/javascript";


### PR DESCRIPTION
# Pull Request: Add `esm://` protocol and enhance MIME type handling

## Overview
This PR introduces a new `esm://` custom protocol handler and improves MIME type detection in `electron_endpoint.js`. These changes enable robust local loading of ES modules and WASM binaries, which is essential for offline integrations like MediaPipe.

## Key Changes

### 1. `esm://` Custom Protocol
- **Scheme Registration**: Registered `esm` as a privileged scheme with support for `secure`, `stream`, `bypassCSP`, `fetchAPI`, and `CORS`.
- **Protocol Handler**: Implemented a new handler for `esm://` that:
  - Supports both absolute and relative file paths.
  - Automatically resolves project-relative paths using `helper.fileURLToPath`.
  - Sets `Access-Control-Allow-Origin: *` to prevent CORS issues during local development.

### 2. Enhanced MIME Type Detection
- **Explicit JS/MJS Mapping**: Forced `text/javascript` MIME type for files ending in `.js` or `.mjs`.
- **WASM Support**: Added explicit mapping for `.wasm` files to `application/wasm`.
- **Rationale**: This bypasses issues where the system's default MIME type mapping might be missing or incorrect (e.g., `.mjs` files), which previously caused "Strict MIME type checking" errors in the browser console.

### 3. Build & Environment
- **`.gitignore` Update**: Added `test_MP_patch/*` to ignored files to prevent local test patches from being accidentally committed.

## Context & Rationale
When working with standalone patches and complex libraries like MediaPipe, loading assets locally often hits security and MIME type restrictions. The `esm://` protocol provides a controlled way to load these assets with the necessary headers, while the explicit MIME mapping ensures that the browser correctly interprets modules and binaries.

## Verification
- [x] Verified that `.mjs` files load correctly as modules without MIME type errors.
- [x] Verified that `.wasm` files are served with the correct `application/wasm` header.
- [x] Tested `esm://` protocol with both absolute and relative paths in the Electron environment.
- [x] Tested on MacOS 26.4.1