### PR TITLE
Enable the electron <webview> tag and the experimental html-in-canvas api

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -31,6 +31,7 @@ app.commandLine.appendSwitch("autoplay-policy", "no-user-gesture-required");
 app.commandLine.appendSwitch("no-user-gesture-required", "true");
 app.commandLine.appendSwitch("disable-hid-blocklist", "true");
 app.commandLine.appendSwitch("enable-web-bluetooth");
+app.commandLine.appendSwitch("enable-blink-features", "CanvasDrawElement");
 app.disableDomainBlockingFor3DAPIs();
 
 logger.info("--- starting");
@@ -335,7 +336,8 @@ class ElectronApp
                 "experimentalFeatures": true,
                 "v8CacheOptions": "none",
                 "backgroundThrottling": false,
-                "autoplayPolicy": "no-user-gesture-required"
+                "autoplayPolicy": "no-user-gesture-required",
+                "webviewTag": true
             }
         };
 
@@ -1031,7 +1033,8 @@ class ElectronApp
                             "nodeIntegrationInSubFrames": true,
                             "contextIsolation": false,
                             "backgroundThrottling": false,
-                            "autoplayPolicy": "no-user-gesture-required"
+                            "autoplayPolicy": "no-user-gesture-required",
+                            "webviewTag": true
                         }
                     };
                 }

--- a/src_client/cables_electron.js
+++ b/src_client/cables_electron.js
@@ -86,6 +86,23 @@ export default class CablesElectron
         {
             if (this.editorWindow)
             {
+                 if (window.HTMLWebViewElement && !this.editorWindow.HTMLWebViewElement)
+                {
+                    this.editorWindow.HTMLWebViewElement = window.HTMLWebViewElement;
+                }
+                const editorDoc = this.editorIframe.contentDocument;
+                if (editorDoc)
+                {
+                    const _origCreateElement = editorDoc.createElement.bind(editorDoc);
+                    editorDoc.createElement = (tagName, options) =>
+                    {
+                        if (tagName && typeof tagName === "string" && tagName.toLowerCase() === "webview")
+                        {
+                            return document.createElement("webview", options);
+                        }
+                        return _origCreateElement(tagName, options);
+                    };
+                }
                 const waitForUi = this.editorWindow.waitForAce;
                 this.editorWindow.waitForAce = () =>
                 {

--- a/src_client/cables_electron.js
+++ b/src_client/cables_electron.js
@@ -86,23 +86,6 @@ export default class CablesElectron
         {
             if (this.editorWindow)
             {
-                 if (window.HTMLWebViewElement && !this.editorWindow.HTMLWebViewElement)
-                {
-                    this.editorWindow.HTMLWebViewElement = window.HTMLWebViewElement;
-                }
-                const editorDoc = this.editorIframe.contentDocument;
-                if (editorDoc)
-                {
-                    const _origCreateElement = editorDoc.createElement.bind(editorDoc);
-                    editorDoc.createElement = (tagName, options) =>
-                    {
-                        if (tagName && typeof tagName === "string" && tagName.toLowerCase() === "webview")
-                        {
-                            return document.createElement("webview", options);
-                        }
-                        return _origCreateElement(tagName, options);
-                    };
-                }
                 const waitForUi = this.editorWindow.waitForAce;
                 this.editorWindow.waitForAce = () =>
                 {


### PR DESCRIPTION
This PR enables 2 features for rendering HTML to texture.

 1. Html-in-canvas api. Now that Cables Standalone uses electron 43 the experimental html-in-canvas api is available. this feature replaces libraries like html2canvas with a faster native api to render html to a texture.  [https://github.com/WICG/html-in-canvas](https://github.com/WICG/html-in-canvas)

 2. electron webview tag. This feature allows external content to be embedded in a patch, like an iframe.  The webview tag allows for cross origin scripting.   Combining html-in-canvas and the webview tag allows cross origin content to be rendered to a texture. 

 I tried to do the same process with an iframe, but was not successful.       

 Tested in macOS 26.5 and Github codespaces 
 
 Anti-gravity AI was used to develop this PR